### PR TITLE
Fix bubble chart hoverRadius behavior to properly handle zero values

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -111,11 +111,17 @@ export default class BubbleController extends DatasetController {
     }
 
     // Custom radius resolution
-    const radius = values.radius;
-    if (mode !== 'active') {
-      values.radius = 0;
+    if (mode === 'active') {
+      // In active mode, values.radius contains hoverRadius
+      // Get base radius for fallback when no custom data radius
+      const baseValues = super.resolveDataElementOptions(index, 'default');
+      const dataRadius = valueOrDefault(parsed && parsed._custom, baseValues.radius);
+      // Final radius = data radius + hover radius
+      values.radius = dataRadius + values.radius;
+    } else {
+      // In normal mode, use data radius or fall back to base radius
+      values.radius = valueOrDefault(parsed && parsed._custom, values.radius);
     }
-    values.radius += valueOrDefault(parsed && parsed._custom, radius);
 
     return values;
   }

--- a/test/specs/controller.bubble.tests.js
+++ b/test/specs/controller.bubble.tests.js
@@ -358,5 +358,23 @@ describe('Chart.controllers.bubble', function() {
       expect(point.options.borderWidth).toBe(2);
       expect(point.options.radius).toBe(20);
     });
+
+    it ('should handle hoverRadius: 0 to maintain bubble size on hover', async function() {
+      var chart = this.chart;
+      var point = chart.getDatasetMeta(0).data[0];
+
+      Chart.helpers.merge(chart.data.datasets[0], {
+        hoverRadius: 0
+      });
+
+      chart.update();
+
+      // With hoverRadius: 0, bubble should maintain its original size (20)
+      await jasmine.triggerMouseEvent(chart, 'mousemove', point);
+      expect(point.options.radius).toBe(20);
+
+      await jasmine.triggerMouseEvent(chart, 'mouseout', point);
+      expect(point.options.radius).toBe(20);
+    });
   });
 });


### PR DESCRIPTION
The bubble chart hoverRadius option behaves unexpectedly when set to 0. According to the documentation, hoverRadius represents 'additional radius' when a bubble is hovered, but setting it to 0 causes bubbles to disappear on hover instead of maintaining their original size.

## Root Cause
In src/controllers/controller.bubble.js, the resolveDataElementOptions method sets values.radius = 0 for non-active mode, then adds the custom radius from data. However, when in active/hover mode, it uses the hoverRadius value directly without properly handling the case where hoverRadius should be 0 (no change on hover).

The issue is in the resolveDataElementOptions method around lines 104-110. The logic needs to be fixed so that:
1. In normal mode: radius = 0 + data.r (base radius from data)
2. In hover/active mode: radius = 0 + data.r + hoverRadius (base radius + additional hover radius)

## Expected Fix
Modify the resolveDataElementOptions method in src/controllers/controller.bubble.js to:
1. Get the base radius from values.radius before any modifications
2. For non-active mode: set radius to 0 + custom data radius
3. For active mode: set radius to 0 + custom data radius + hoverRadius (where hoverRadius is already resolved as the hover value)

The key is that in active mode, values.radius contains hoverRadius (not the base radius), so we need to treat it as additive to the data radius.

## Test Requirements
Add a test case in test/specs/controller.bubble.tests.js to verify:
1. When hoverRadius is 0, bubbles maintain their original size on hover
2. When hoverRadius is set to a positive value, it adds to the base radius
3. The behavior is consistent with the documentation description of 'additional radius'

Refer to existing tests around line 290-340 in controller.bubble.tests.js for the pattern.