### PR TITLE
Fix hoverRadius to be additive for line/radar charts

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -99,6 +99,29 @@ export default class LineController extends DatasetController {
     return Math.max(border, firstPoint, lastPoint) / 2;
   }
 
+  /**
+	 * @param {number} index
+	 * @param {string} [mode]
+	 * @protected
+	 */
+  resolveDataElementOptions(index, mode) {
+    let values = super.resolveDataElementOptions(index, mode);
+
+    // Make hoverRadius additive to base radius (consistent with bubble charts)
+    if (mode === 'active') {
+      // In case values were cached (and thus frozen), we need to clone the values
+      if (values.$shared) {
+        values = Object.assign({}, values, {$shared: false});
+      }
+
+      const baseRadius = super.resolveDataElementOptions(index, 'default').radius;
+      const hoverRadius = values.radius;
+      values.radius = baseRadius + hoverRadius;
+    }
+
+    return values;
+  }
+
   draw() {
     const meta = this._cachedMeta;
     meta.dataset.updateControlPoints(this.chart.chartArea, meta.iScale.axis);

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -67,6 +67,29 @@ export default class RadarController extends DatasetController {
       this.updateElement(point, i, properties, mode);
     }
   }
+
+  /**
+	 * @param {number} index
+	 * @param {string} [mode]
+	 * @protected
+	 */
+  resolveDataElementOptions(index, mode) {
+    let values = super.resolveDataElementOptions(index, mode);
+
+    // Make hoverRadius additive to base radius (consistent with bubble charts)
+    if (mode === 'active') {
+      // In case values were cached (and thus frozen), we need to clone the values
+      if (values.$shared) {
+        values = Object.assign({}, values, {$shared: false});
+      }
+
+      const baseRadius = super.resolveDataElementOptions(index, 'default').radius;
+      const hoverRadius = values.radius;
+      values.radius = baseRadius + hoverRadius;
+    }
+
+    return values;
+  }
 }
 
 RadarController.id = 'radar';

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -789,7 +789,7 @@ describe('Chart.controllers.line', function() {
       expect(point.options.backgroundColor).toBe('rgb(200, 100, 150)');
       expect(point.options.borderColor).toBe('rgb(150, 50, 100)');
       expect(point.options.borderWidth).toBe(8.4);
-      expect(point.options.radius).toBe(4.2);
+      expect(point.options.radius).toBe(3 + 4.2);
 
       await jasmine.triggerMouseEvent(chart, 'mouseout', point);
       expect(point.options.backgroundColor).toBe('rgb(100, 150, 200)');
@@ -815,7 +815,7 @@ describe('Chart.controllers.line', function() {
       expect(point.options.backgroundColor).toBe('rgb(200, 100, 150)');
       expect(point.options.borderColor).toBe('rgb(150, 50, 100)');
       expect(point.options.borderWidth).toBe(8.4);
-      expect(point.options.radius).toBe(4.2);
+      expect(point.options.radius).toBe(3 + 4.2);
 
       await jasmine.triggerMouseEvent(chart, 'mouseout', point);
       expect(point.options.backgroundColor).toBe('rgb(100, 150, 200)');

--- a/test/specs/controller.radar.tests.js
+++ b/test/specs/controller.radar.tests.js
@@ -284,7 +284,7 @@ describe('Chart.controllers.radar', function() {
       expect(point.options.backgroundColor).toBe('rgb(200, 100, 150)');
       expect(point.options.borderColor).toBe('rgb(150, 50, 100)');
       expect(point.options.borderWidth).toBe(8.4);
-      expect(point.options.radius).toBe(4.2);
+      expect(point.options.radius).toBe(3 + 4.2);
 
       await jasmine.triggerMouseEvent(chart, 'mouseout', point);
       expect(point.options.backgroundColor).toBe('rgb(100, 150, 200)');
@@ -310,7 +310,7 @@ describe('Chart.controllers.radar', function() {
       expect(point.options.backgroundColor).toBe('rgb(200, 100, 150)');
       expect(point.options.borderColor).toBe('rgb(150, 50, 100)');
       expect(point.options.borderWidth).toBe(8.4);
-      expect(point.options.radius).toBe(4.2);
+      expect(point.options.radius).toBe(3 + 4.2);
 
       await jasmine.triggerMouseEvent(chart, 'mouseout', point);
       expect(point.options.backgroundColor).toBe('rgb(100, 150, 200)');


### PR DESCRIPTION
## Problem

The `hoverRadius` option is documented as "additional radius when hovered" across all point-based charts (bubble, line, radar, scatter). However, the implementation is inconsistent:

- **Bubble charts**: `hoverRadius` is correctly added to base radius (`radius = baseRadius + hoverRadius`)
- **Line/Radar charts**: `hoverRadius` incorrectly replaces the base radius (`radius = hoverRadius`)

## Expected Behavior

According to the documentation:
- `hoverRadius: 0` should mean no size change on hover (bubble stays at base radius)
- `hoverRadius: 5` with `radius: 10` should result in `radius: 15` on hover

## Solution

Make line, radar, and scatter controllers behave consistently with bubble charts by making `hoverRadius` additive to the base radius, not a replacement value.

## Test Evidence

### Bubble chart tests (correct):
```javascript
expect(point.options.radius).toBe(20 + 4.2); // when hovered
expect(point.options.radius).toBe(20); // when not hovered
```

### Line/Radar chart tests (incorrect):
```javascript
expect(point.options.radius).toBe(4.2); // when hovered - should be 3 + 4.2 = 7.2
expect(point.options.radius).toBe(3); // when not hovered
```

## Implementation Notes

1. Review how bubble controller handles this in `controller.bubble.js` - it has special logic in `resolveDataElementOptions` that adds the hover radius
2. Apply similar logic to line, radar, and scatter controllers OR update the base controller to handle this consistently
3. Update existing tests to expect additive behavior
4. Ensure backward compatibility considerations are documented

## Files to Review

- `src/controllers/controller.bubble.js` - reference implementation
- `src/controllers/controller.line.js`
- `src/controllers/controller.radar.js`
- `src/controllers/controller.scatter.js`
- Test files: `controller.line.tests.js`, `controller.radar.tests.js`
- Documentation already states correct behavior in `docs/charts/bubble.md`