### PR TITLE
Fix bubble chart hoverRadius behavior - treat as additional radius

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -111,11 +111,17 @@ export default class BubbleController extends DatasetController {
     }
 
     // Custom radius resolution
-    const radius = values.radius;
-    if (mode !== 'active') {
-      values.radius = 0;
+    // The base radius comes from the data point's 'r' property
+    const baseRadius = valueOrDefault(parsed && parsed._custom, 0);
+
+    if (mode === 'active') {
+      // For hover/active state: add hoverRadius to base radius
+      // values.radius contains hoverRadius from parent resolution
+      values.radius = baseRadius + values.radius;
+    } else {
+      // For normal state: use only base radius from data
+      values.radius = baseRadius;
     }
-    values.radius += valueOrDefault(parsed && parsed._custom, radius);
 
     return values;
   }


### PR DESCRIPTION
## Problem

The `hoverRadius` option in bubble charts doesn't behave as documented. According to the documentation at `/docs/charts/bubble.md`, `hoverRadius` should represent **additional** radius when hovered (in pixels). However, the current implementation treats it as an absolute value, causing unexpected behavior:

- When `hoverRadius: 0`, bubbles disappear on hover instead of maintaining their base size
- When `hoverRadius` equals the base radius, the bubble size changes instead of staying the same

## Root Cause

In `/src/controllers/controller.bubble.js`, the `resolveDataElementOptions` method has incorrect logic:

```javascript
const radius = values.radius;
if (mode !== 'active') {
  values.radius = 0;
}
values.radius += valueOrDefault(parsed && parsed._custom, radius);
```

This code:
1. Sets `values.radius = 0` when NOT active (normal state)
2. Then adds the data's custom radius value

This means:
- **Normal state**: radius = 0 + data.r (correct)
- **Active/hover state**: radius = hoverRadius + data.r (WRONG - should be data.r + hoverRadius)

The issue is that when hovering, `values.radius` already contains `hoverRadius` from the parent's `resolveDataElementOptions`, but the code doesn't preserve the base radius. It should add hoverRadius to the base radius, not replace it.

## Solution

Fix the logic to properly handle the hover state. The correct behavior should be:

1. Store the original base radius before any modifications
2. For normal mode: use base radius from data's custom `r` value
3. For active/hover mode: use base radius from data's custom `r` value PLUS the hoverRadius

## Implementation

Replace the `resolveDataElementOptions` method in `/src/controllers/controller.bubble.js` with:

```javascript
resolveDataElementOptions(index, mode) {
  const parsed = this.getParsed(index);
  let values = super.resolveDataElementOptions(index, mode);

  // In case values were cached (and thus frozen), we need to clone the values
  if (values.$shared) {
    values = Object.assign({}, values, {$shared: false});
  }

  // Custom radius resolution
  // The base radius comes from the data point's 'r' property
  const baseRadius = valueOrDefault(parsed && parsed._custom, 0);

  if (mode === 'active') {
    // For hover/active state: add hoverRadius to base radius
    // values.radius contains hoverRadius from parent resolution
    values.radius = baseRadius + values.radius;
  } else {
    // For normal state: use only base radius from data
    values.radius = baseRadius;
  }

  return values;
}
```

## Expected Behavior After Fix

- `hoverRadius: 0` → bubble maintains its base size on hover (no additional radius)
- `hoverRadius: 5` with `r: 10` → bubble goes from 10px to 15px on hover
- Matches behavior documented in `/docs/charts/bubble.md`
- Aligns with test expectations in `/test/specs/controller.bubble.tests.js`

## References

- Issue: #2
- Documentation: `/docs/charts/bubble.md` line defining hoverRadius as "bubble **additional** radius when hovered"
- Tests: `/test/specs/controller.bubble.tests.js` expects `radius: 20 + 4.2` for hoverRadius behavior