### PR TITLE
Fix bubble chart hoverRadius behavior

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -111,11 +111,18 @@ export default class BubbleController extends DatasetController {
     }
 
     // Custom radius resolution
-    const radius = values.radius;
-    if (mode !== 'active') {
-      values.radius = 0;
+    const customRadius = valueOrDefault(parsed && parsed._custom, 0);
+
+    // For reset mode, start from 0 for animation
+    if (mode === 'reset') {
+      values.radius = customRadius;
+    } else if (mode === 'active') {
+      // In active mode, values.radius contains hoverRadius which should be ADDED to the data radius
+      values.radius = customRadius + values.radius;
+    } else {
+      // In normal mode, use only the data radius
+      values.radius = customRadius;
     }
-    values.radius += valueOrDefault(parsed && parsed._custom, radius);
 
     return values;
   }


### PR DESCRIPTION
## Problem

The `hoverRadius` option in bubble charts doesn't behave as documented. According to the documentation, `hoverRadius` represents **additional radius** when a bubble is hovered. However, the current implementation in `src/controllers/controller.bubble.js` has incorrect logic:

```javascript
resolveDataElementOptions(index, mode) {
  const parsed = this.getParsed(index);
  let values = super.resolveDataElementOptions(index, mode);

  if (values.$shared) {
    values = Object.assign({}, values, {$shared: false});
  }

  // Custom radius resolution - BUG HERE
  const radius = values.radius;
  if (mode !== 'active') {
    values.radius = 0;  // ❌ Wrong: sets to 0 when NOT active
  }
  values.radius += valueOrDefault(parsed && parsed._custom, radius);

  return values;
}
```

## Current Behavior

- When `hoverRadius: 0`, bubbles disappear on hover
- The radius calculation is inverted

## Expected Behavior

When hovering:
- `hoverRadius` should be ADDED to the base radius
- Setting `hoverRadius: 0` should result in no size change on hover

## Solution

The logic should be:

1. Start with base radius from options (which includes hoverRadius when mode is 'active')
2. Add the custom radius from data (the 'r' property)
3. For non-active mode (reset), set radius to 0 for animation purposes

```javascript
resolveDataElementOptions(index, mode) {
  const parsed = this.getParsed(index);
  let values = super.resolveDataElementOptions(index, mode);

  if (values.$shared) {
    values = Object.assign({}, values, {$shared: false});
  }

  // Custom radius resolution - FIXED
  const radius = values.radius;

  // For reset mode, start from 0 for animation
  if (mode === 'reset') {
    values.radius = 0;
  }

  // Add custom radius from data
  values.radius += valueOrDefault(parsed && parsed._custom, mode === 'reset' ? 0 : radius);

  return values;
}
```

Wait, let me re-analyze. Looking at the tests:

```javascript
expect(point.options.radius).toBe(20 + 4.2); // base radius (20) + hoverRadius (4.2)
```

The base radius is 20 (from data r property), and hoverRadius 4.2 should be added.

The actual fix should preserve the parent's resolved radius (which includes hoverRadius when active) and add the data's custom radius:

```javascript
resolveDataElementOptions(index, mode) {
  const parsed = this.getParsed(index);
  let values = super.resolveDataElementOptions(index, mode);

  if (values.$shared) {
    values = Object.assign({}, values, {$shared: false});
  }

  // Get the custom radius from data
  const customRadius = valueOrDefault(parsed && parsed._custom, 0);

  // For reset mode, only use custom radius (starting from 0)
  if (mode === 'reset') {
    values.radius = 0;
  }

  // Add custom radius to the resolved radius (which includes hoverRadius when mode is 'active')
  values.radius += customRadius;

  return values;
}
```

Please update the `resolveDataElementOptions` method in `src/controllers/controller.bubble.js` to fix this issue.